### PR TITLE
Fix type mismatch in MacroUsage

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -119,8 +119,8 @@ class MacroUsage:
         self.name = element.get('name')
         _load_location(self, element)
         self.usefile = element.get('usefile')
-        self.useline = element.get('useline')
-        self.usecolumn = element.get('usecolumn')
+        self.useline = int(element.get('useline'))
+        self.usecolumn = int(element.get('usecolumn'))
         self.isKnownValue = element.get('is-known-value', 'false') == 'true'
 
     def __repr__(self):


### PR DESCRIPTION
Fix type mismatch in MacroUsage: line and column information is of type int everywhere, except in MacroUsage.

I wanted to parse the macro's to get the name of a macro, that was used at a certain place. To make a custom check.